### PR TITLE
Added argparser, fixed exception handling, removed unnecessary modules

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,62 +1,44 @@
-import os
-import sys
-import time
+import argparse
 import virtualbox
-
 from datetime import datetime
-from vboxapi import VirtualBoxManager
 
 vbox = virtualbox.VirtualBox()
 session = virtualbox.Session()
 
-def check_arguments():
-    if len(sys.argv) < 2:
-        print("Not enough argument provided")
-        return 1
-    elif not isinstance(sys.argv[1], str):
-        print("Provided name is not istance of string")
-        return 1
-    return sys.argv[1]
-
-def delete_last_snapshot(machine_name=None):
-
-    if machine_name:
+def delete_last_snapshot(machine_name):
+    try:
         virtual_machine = vbox.find_machine(machine_name)
-        try:
-            root_snapshot = virtual_machine.find_snapshot("")
-            idx = 0
-            #children = root_snapshot.children
-            current_snapshot = root_snapshot
-            first_snapshot = list()
-            last_snapshot = str()
+        root_snapshot = virtual_machine.find_snapshot("")
+        idx = 0
+        #children = root_snapshot.children
+        current_snapshot = root_snapshot
+        first_snapshot = list()
+        last_snapshot = str()
 
-            while True:
-                children = current_snapshot.children
-                for child in children:
-                    snapshot_child = virtual_machine.find_snapshot(child.id_p)
-                if idx == 0:
-                    first_snapshot = snapshot_child.id_p, snapshot_child.name
-                    idx += 1
-                last_snapshot = snapshot_child.id_p
-                if snapshot_child.children_count == 0:
-                    break
-                current_snapshot = snapshot_child
+        while True:
+            children = current_snapshot.children
+            for child in children:
+                snapshot_child = virtual_machine.find_snapshot(child.id_p)
+            if idx == 0:
+                first_snapshot = snapshot_child.id_p, snapshot_child.name
+                idx += 1
+            last_snapshot = snapshot_child.id_p
+            if snapshot_child.children_count == 0:
+                break
+            current_snapshot = snapshot_child
 
-            if first_snapshot[0] != last_snapshot:
-                virtual_machine.lock_machine(session, virtualbox.library.LockType(1))
-                process = session.machine.delete_snapshot(first_snapshot[0])
-                process.wait_for_completion(timeout=-1)
-                print("Deleted " + first_snapshot[1])
-        except:
-            print("Delete " + machine_name + " snapshot failed")
-            return
-    else:
-        print("machine_name is None")
+        if first_snapshot[0] != last_snapshot:
+            virtual_machine.lock_machine(session, virtualbox.library.LockType(1))
+            process = session.machine.delete_snapshot(first_snapshot[0])
+            process.wait_for_completion(timeout=-1)
+            print("Deleted " + first_snapshot[1])
+    except Exception as ex:
+        print(f"Snapshot deletion exited prematurely with following exception: {ex}")
+        return
 
-def create_snapshot(machine_name=None):
+def create_snapshot(machine_name):
     vm_initial_status = 1  # zero means powered on
-
-    if machine_name:
+    try:
         machine = vbox.find_machine(machine_name)
         if machine.state == virtualbox.library.MachineState(1):  # MachineState(1) = PowerOff
             vm_initial_status = 0
@@ -84,19 +66,37 @@ def create_snapshot(machine_name=None):
         if vm_initial_status:
             if session.state == virtualbox.library.SessionState(2):
                 session.unlock_machine()
-    else:
-        print("machine_name is None")
+    except Exception as ex:
+        print(f"Snapshot creation exited prematurely with following exception: {ex}")
+        # This will skip power down of machine on failure
+        return 1
     
     return vm_initial_status
     
 def main():
+    parser = argparse.ArgumentParser(
+                    prog = "VirtualBox Snapshotter",
+                    description = "Takes new snapshot and deletes old one\
+                    for specified Virtual Machine (VM).",
+                    epilog="Get the latest release of VirtualBox Snapshotter from: https://github.com/Meru3m/virtualbox-snapshotter")
+    parser.add_argument("vm_name",
+                        action="store",
+                        help="Virtual Machine (VM) name enclosed in double quotes (i.e. \"Awesome Virtual Machine\").\
+                            Not using double quotes may lead to abnormal behaviour if name contains whitespaces.",
+                        metavar="\"VM_NAME\"",
+                        type=str
+                        )
+    args = parser.parse_args()
     print("Starting autosnapshotter script ...")
-    name = check_arguments()
-    delete_last_snapshot(name)
-    vm_status = create_snapshot(name)
+    delete_last_snapshot(args.vm_name)
+    vm_status = create_snapshot(args.vm_name)
 
-    if not vm_status:
-        session.console.power_down()
+    try:
+        if not vm_status:
+            session.console.power_down()
+    except Exception as ex:
+        print(f"Power down of virtual machine execution exited prematurely with following exception: {ex}")
+        return
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I am currently working on slightly different implementation of VM snapshotter via Python. However, I am still using this project as foundation. So, here is my contribution to this project. (Thanks for making the code public btw)

Following changes were made:

- Introduced `argparser` - now help menu can be accessed (using `-h` or `--help`) and no annoying `check_arguments` method is needed as argparser will perform checks by itself. The method of passing in VM name remains the same: `python main.py "Awesome VM Name"`
- Introduced `try...except` statements within `delete_last_snapshot` and `create_snapshot` in case non-existing VM name is provided (or any other exception is risen)
- Cleansed unused module imports
