### PR TITLE
Delete ignore, list snapshot details

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -36,8 +36,6 @@ pydocstyle:
 pylint:
   options:
     min-public-methods: 1
-  disable:
-    - C0114 # Missing-module-docstring / Missing module docstring
 mccabe:
   disable:
     # Temporary disable while inline skipping is unsupported

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -38,7 +38,6 @@ pylint:
     min-public-methods: 1
   disable:
     - C0114 # Missing-module-docstring / Missing module docstring
-    - W0718 # Catching too general exception
 mccabe:
   disable:
     # Temporary disable while inline skipping is unsupported

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ python virtualbox_snapshotter.py "My awesome VM" -r 10 -n "My awesome snapshot n
 
 ---
 
-This will retain 15 snapshots (potentially - more, depending on `ignore.txt` content), will write a custom snapshot name and snapshot description, ignore deleting snapshots as specified in `ignore.txt`. Other optional parameters will use default values:
+This will retain 15 snapshots (potentially - more, depending on `ignore.txt` content), will write a custom snapshot name and snapshot description, ignore deleting specific snapshots as specified in `ignore.txt`. Other optional parameters will use default values:
 
 ```bash
 python virtualbox_snapshotter.py "My awesome VM" -r 15 -n "My awesome snapshot name" -d "My awesome snapshot description" -i "ignore.txt"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ This will retain 10 snapshots, will write a custom snapshot name and snapshot de
 python virtualbox_snapshotter.py "My awesome VM" -r 10 -n "My awesome snapshot name" -d "My awesome snapshot description"
 ```
 
+---
+
+This will retain 15 snapshots (potentially - more, depending on `ignore.txt` content), will write a custom snapshot name and snapshot description, ignore deleting snapshots as specified in `ignore.txt`. Other optional parameters will use default values:
+
+```bash
+python virtualbox_snapshotter.py "My awesome VM" -r 15 -n "My awesome snapshot name" -d "My awesome snapshot description" -i "ignore.txt"
+```
+
+---
+
+This will list all snapshots (if any) and their details (name, UUID, date) for selected virtual machine:
+
+```bash
+python virtualbox_snapshotter.py "My awesome VM" -l
+```
+
 ## Scheduling
 
 The script itself does not provide an ability to schedule when it should be run. However, most mainstream operating systems provide an ability to schedule tasks:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ __Note__ Remember to run the installation command from within the project direct
 ## Usage
 
 ```bash
-usage: VirtualBox Snapshotter [-h] [-r 0-1000] [-v] [-n "CUSTOM_NAME"] [-d "CUSTOM_DESCRIPTION"] "VIRTUAL_MACHINE_NAME"
+usage: VirtualBox Snapshotter [-h] [-r 0-1000] [-v] [-n "CUSTOM_SNAPSHOT_NAME"] [-d "CUSTOM_SNAPSHOT_DESCRIPTION"] [-i "SNAPSHOT_IGNORE_FILENAME"] [-l] "VIRTUAL_MACHINE_NAME"
 ```
 
 ### Positional parameter
@@ -54,9 +54,17 @@ __NOTE__ Without specifying this parameter, script will fail to run.
 
 - `-h` or `--help` - displays a help message
 - `-v` or `--verbose` - script will become more verbose (will produce more textual output). Useful for debugging.
-- `-r NUMBER` or `--retain NUMBER` - Number of latest snapshots to retain. Replace `NUMBER` with a number between 0 (incl.) and 1000 (incl.). If 0 is provided - deletes all snapshots leaving just the latest one. If argument is not provided, defaults to 3.
-- `-n "CUSTOM_NAME"` or `--name "CUSTOM_NAME"` - Customise name for a snapshot. Replace `CUSTOM_NAME` to any text for a custom snapshot name. Make sure to enclose your custom snapshot name within double quotes ("). If argument is not provided, defaults to "Regular Snapshot CURRENT_DATE"
-- `-d "CUSTOM_DESCRIPTION"` or `--description "CUSTOM_DESCRIPTION"` - Customise description for a snapshot. Replace `CUSTOM_DESCRIPTION` to any text for a custom snapshot description. Make sure to enclose your custom snapshot description within double quotes ("). If argument is not provided, defaults to "Regular Snapshot taken on CURRENT_DATE via virtualbox-snapshotter"
+- `-r NUMBER` or `--retain NUMBER` - Number of latest snapshots to retain. Replace `NUMBER` with a number between 0 (incl.) and 1000 (incl.). When used with `-i`/`--ignore`, counts only those snapshots, that are NOT ignored. I.e. 2 snapshot are ignored via `-i`/`--ignore`, 3 snapshots specified for `-r`/`--retain`, resulting number of preserved snapshots will be 5. If 0 is provided - deletes all snapshots leaving just the latest one. If argument is not provided, defaults to 3.
+- `-n "CUSTOM_SNAPSHOT_NAME"` or `--name "CUSTOM_SNAPSHOT_NAME"` - Customise name for a snapshot. Replace `CUSTOM_SNAPSHOT_NAME` to any text for a custom snapshot name. Make sure to enclose your custom snapshot name within double quotes ("). If argument is not provided, defaults to `Regular Snapshot CURRENT_DATE`
+- `-d "CUSTOM_SNAPSHOT_DESCRIPTION"` or `--description "CUSTOM_SNAPSHOT_DESCRIPTION"` - Customise description for a snapshot. Replace `CUSTOM_SNAPSHOT_DESCRIPTION` to any text for a custom snapshot description. Make sure to enclose your custom snapshot description within double quotes ("). If argument is not provided, defaults to `Regular Snapshot taken on CURRENT_DATE via virtualbox-snapshotter`
+- `-i SNAPSHOT_IGNORE_FILENAME` or `--ignore SNAPSHOT_IGNORE_FILENAME` - Path to a file, containing snapshot UUIDs to be ignored from deletion. Snapshot UUIDs specified within a file will never be deleted. Snapshot UUIDs can be found via [VBoxManage](https://www.virtualbox.org/manual/ch08.html#vboxmanage-snapshot) or via this script, using `-l`/`--list` argument. `SNAPSHOT_IGNORE` file supports comments - any text after `#` will be ignored. Moreover, any whitespace within a file is ignored. Example structure of `SNAPSHOT_IGNORE` file:
+
+```text
+5ead9089-84f2-4883-969a-0eae3cda0813    # this is very cool snapshot ID which will never be deleted
+aeeff25-62b1-ffa5-521f-e26a3cda11ab     # this is another very cool snapshot ID which will never be deleted
+```
+
+- `-l` or `--list` - Lists all snapshots and their details (name, UUID, date) for selected virtual machine. When `-l`/`--list` is specified, no actions (i.e. snapshot delete, machine lock etc) are performed on a virtual machine apart from reading virtual machine's details. When `-l`/`--list` argument is used, any other optional argument has no effect.
 
 ### Optional parameter defaults
 

--- a/virtualbox_snapshotter.py
+++ b/virtualbox_snapshotter.py
@@ -4,57 +4,6 @@ import logging
 
 import virtualbox
 
-vbox = virtualbox.VirtualBox()
-session = virtualbox.Session()
-
-parser = argparse.ArgumentParser(prog="VirtualBox Snapshotter",
-                                 description="Takes new snapshots and deletes old ones\
-                                             for specified Virtual Machine.",
-                                 epilog="Currently, multi children are not supported.\
-                                        Nested children are supported.")
-parser.add_argument("machine_name",
-                    action="store",
-                    help="(Required) Virtual Machine (VM) name enclosed in double quotes (\").\
-                         Not using double quotes may lead to abnormal behaviour if name contains whitespaces.",
-                    metavar="\"VIRTUAL_MACHINE_NAME\"",
-                    type=str)
-
-parser.add_argument("-r", "--retain",
-                    action="store",
-                    choices=range(0, 1000),
-                    default=3,
-                    help="Number of latest snapshots to retain.\
-                         If 0 is provided - deletes all snapshots leaving just the latest one.\
-                         If argument is not provided, defaults to 3.",
-                    metavar="(0-1000)",
-                    type=int,
-                    required=False)
-
-parser.add_argument("-v", "--verbose",
-                    action="store_true",
-                    help="Adds verbosity",
-                    required=False)
-
-parser.add_argument("-n", "--name",
-                    action="store",
-                    help="Custom name for a snapshot.\
-                         If argument is not provided, defaults to 'Regular Snapshot DATE'",
-                    metavar="\"CUSTOM_NAME\"",
-                    type=str,
-                    default="Regular Snapshot",
-                    required=False)
-
-parser.add_argument("-d", "--description",
-                    action="store",
-                    help="Custom description for a snapshot.\
-                         If argument is not provided, defaults to \
-                         'Regular Snapshot taken on DATE via virtualbox-snapshotter'",
-                    metavar="\"CUSTOM_DESCRIPTION\"",
-                    type=str,
-                    default="Regular Snapshot taken on",
-                    required=False)
-args = parser.parse_args()
-
 
 def delete_oldest_snapshots(machine_name: str, number_to_retain: int) -> None:
     """
@@ -202,7 +151,65 @@ if __name__ == "__main__":
     # Default log level is WARNING
     logger.setLevel(logging.WARNING)
 
+    # Global placeholders
+    vbox = virtualbox.VirtualBox()
+    session = virtualbox.Session()
+
+    # Adding argparse to application
+    parser = argparse.ArgumentParser(prog="VirtualBox Snapshotter",
+                                     description="Takes new snapshots and deletes old ones\
+                                                 for specified Virtual Machine.",
+                                     epilog="Currently, multi children are not supported.\
+                                            Nested children are supported.")
+
+    # Adding arguments to argparse
+    parser.add_argument("machine_name",
+                        action="store",
+                        help="(Required) Virtual Machine (VM) name enclosed in double quotes (\").\
+                            Not using double quotes may lead to abnormal behaviour if name contains whitespaces.",
+                        metavar="\"VIRTUAL_MACHINE_NAME\"",
+                        type=str)
+
+    parser.add_argument("-r", "--retain",
+                        action="store",
+                        choices=range(0, 1000),
+                        default=3,
+                        help="Number of latest snapshots to retain.\
+                            If 0 is provided - deletes all snapshots leaving just the latest one.\
+                            If argument is not provided, defaults to 3.",
+                        metavar="(0-1000)",
+                        type=int,
+                        required=False)
+
+    parser.add_argument("-v", "--verbose",
+                        action="store_true",
+                        help="Adds verbosity",
+                        required=False)
+
+    parser.add_argument("-n", "--name",
+                        action="store",
+                        help="Custom name for a snapshot.\
+                            If argument is not provided, defaults to 'Regular Snapshot DATE'",
+                        metavar="\"CUSTOM_NAME\"",
+                        type=str,
+                        default="Regular Snapshot",
+                        required=False)
+
+    parser.add_argument("-d", "--description",
+                        action="store",
+                        help="Custom description for a snapshot.\
+                            If argument is not provided, defaults to \
+                            'Regular Snapshot taken on DATE via virtualbox-snapshotter'",
+                        metavar="\"CUSTOM_DESCRIPTION\"",
+                        type=str,
+                        default="Regular Snapshot taken on",
+                        required=False)
+
+    # Parsing arguments
+    args = parser.parse_args()
+
     if args.verbose:
         # When verbosity flag is set, log level is changed to INFO
         logger.setLevel(logging.INFO)
+
     main()

--- a/virtualbox_snapshotter.py
+++ b/virtualbox_snapshotter.py
@@ -1,3 +1,26 @@
+"""
+MIT License.
+
+Copyright (c) 2020 Mattia Baldari
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
 from datetime import datetime
 import argparse
 import logging

--- a/virtualbox_snapshotter.py
+++ b/virtualbox_snapshotter.py
@@ -58,20 +58,17 @@ args = parser.parse_args()
 # pylint: disable=too-many-branches
 def delete_oldest_snapshots(machine_name: str, number_to_retain: int) -> None:
     """
-    Attempts to delete oldests snapshots from specified machine.
+    Attempts to delete oldest snapshots from specified machine.
 
-    in machine_name of type str
-        Machine name to search for.
-
-    in number_to_retain of type int
-        Number of newest snapshots to retain.
-
+    :param str machine_name: machine name to search for
+    :param int number_to_retain: number of newest snapshots to retain
+    :return: None
     """
     try:
         # Trying to find a machine
         virtual_machine = vbox.find_machine(machine_name)
 
-        # Snapshot ids[0] and names[1] sorted from oldest (index - 0) to newest (index - higest)
+        # Snapshot ids[0] and names[1] sorted from oldest (index - 0) to newest (index - highest)
         snapshot_details = []
         # Getting root snapshot and adding it to a list
         snapshot = virtual_machine.find_snapshot("")
@@ -126,21 +123,19 @@ def delete_oldest_snapshots(machine_name: str, number_to_retain: int) -> None:
 
 def create_snapshot(machine_name: str) -> bool:
     """
-    Attempts to create a snapshot for specified machine.
+    Attempts to create a snapshot for a specified machine.
 
-    in machine_name of type str
-        Machine name to search for.
-
-    return vm_running_initally of type bool
-        Status if machine was in any state but "Powered Off" initally
+    :param str machine_name: machine name to search for
+    :return: status of a machine if it was in any state but "Powered Off" initially
+    :rtype: bool
     """
-    # Assuming that machine is initally in any state but not in "Powered Off"
-    vm_running_initally = True
+    # Assuming that machine is initially in any state but not in "Powered Off"
+    vm_running_initially = True
 
     virtual_machine = vbox.find_machine(machine_name)
     if virtual_machine.state == virtualbox.library.MachineState(1):
         # Check if machine is powered off (MachineState(1) = PowerOff)
-        vm_running_initally = False
+        vm_running_initially = False
 
         if session.state == virtualbox.library.SessionState(2):
             # Check if session is locked (SessionState(2) = Locked)
@@ -154,8 +149,8 @@ def create_snapshot(machine_name: str) -> bool:
     snap_name = f"{args.name} {datetime.now().strftime('%d-%m-%Y')}"
     description = f"{args.description} {datetime.now().strftime('%d-%m-%Y')} via virtualbox-snapshotter"
 
-    if vm_running_initally:
-        # Check if inital state of a machine was anything but "Powered Off"
+    if vm_running_initially:
+        # Check if initial state of a machine was anything but "Powered Off"
         if virtual_machine.session_state == virtualbox.library.SessionState(2):
             # Check if VM session is locked (SessionState(2) = Locked)
             if session.state == virtualbox.library.SessionState(2):
@@ -175,13 +170,13 @@ def create_snapshot(machine_name: str) -> bool:
     if args.verbose:
         print(f"Created snapshot: '{snap_name}'")
 
-    if vm_running_initally:
-        # Check if inital state of a machine was anything but "Powered Off"
+    if vm_running_initially:
+        # Check if initial state of a machine was anything but "Powered Off"
         if session.state == virtualbox.library.SessionState(2):
             # Check if session is locked
             session.unlock_machine()
 
-    return vm_running_initally
+    return vm_running_initially
 
 
 def main():


### PR DESCRIPTION
Hello again!

I finally had some spare time to add extra functionality as per https://github.com/Meru3m/virtualbox-snapshotter/issues/12

Things I have done:
- Fixed typos
- Changed docstrings to be reStructuredText style as it is preferred https://peps.python.org/pep-0287/
- Got rid of most prints, changed them to use `logging` module
- Tidied up code by moving `argparse` to `__main__` to improve support for 3rd party integrations
- Added `-i`/`--ignore` possibility to specify a file with UUIDs which will be preserved. Implemented parser to be able to read UUIDs from file, ignore comments (those, starting with `#`) and ignore whitespaces
- Added `-l`/`--list` possibility to display current virtual machine details such as name, description, UUID. This may be handy for `-i`/`--ignore`
- Updated readme to reflect changes made
- Lifted some ignores from prospector
- Added heading to a *.py file (from LICENSE)
- Changed generic `expect Exception` to more specific ones. Removed `except` where it is not needed

I think all of that can be added as changelog for a release.
Could you make a release `v1.2.0` after approval, please?