### PR TITLE
Return when no snapshots are available and -l/--list is specified, minor improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ This will list all snapshots (if any) and their details (name, UUID, date) for s
 python virtualbox_snapshotter.py "My awesome VM" -l
 ```
 
+## Return codes
+
+Whenever script exits (expectedly or unexpectedly), it will send specific exit code:
+
+- `0` indicates all requested operation completed successfully
+- Any other number indicates the error code that triggered script to terminate prematurely
+
 ## Scheduling
 
 The script itself does not provide an ability to schedule when it should be run. However, most mainstream operating systems provide an ability to schedule tasks:

--- a/virtualbox_snapshotter.py
+++ b/virtualbox_snapshotter.py
@@ -68,16 +68,11 @@ def delete_oldest_snapshots(virtual_machine: virtualbox.lib.IMachine,
 
     if number_to_retain >= len(snapshot_details):
         logger.info("Snapshot deletion skipped. Reason: "
-                    "Number of snapshots to be retained is bigger then number of available snapshots")
+                    "Number of snapshots to be retained is equal or bigger then number of available snapshots")
         return
 
     # Removing number of snapshots from the list of snapshots to be deleted
     snapshot_details = snapshot_details[:len(snapshot_details) - number_to_retain]
-
-    if len(snapshot_details) == 0:
-        # In case all existing snapshots to be retained
-        logger.info("Snapshot deletion skipped. Reason: No snapshots to be deleted found")
-        return
 
     logger.info("List of snapshots to be deleted:")
     for snapshot in snapshot_details:

--- a/virtualbox_snapshotter.py
+++ b/virtualbox_snapshotter.py
@@ -46,7 +46,7 @@ def delete_oldest_snapshots(virtual_machine: virtualbox.lib.IMachine,
     :param int number_to_retain: number of snapshots to retain
     :return: None
     """
-    if snapshot_details is None:
+    if not snapshot_details:
         logger.info("Snapshot deletion skipped. Reason: No snapshots found")
         return
 
@@ -191,7 +191,7 @@ def parse_snapshot_ignore_file(filename: str) -> list:
     return uuids
 
 
-def load_virtual_machine(machine_name: str):
+def load_virtual_machine(machine_name: str) -> virtualbox.lib.IMachine:
     """
     Getting a virtual machine as a class. On error, exits application.
 
@@ -212,13 +212,13 @@ def load_virtual_machine(machine_name: str):
     return virtual_machine
 
 
-def load_snapshot_details(virtual_machine: virtualbox.lib.IMachine):
+def load_snapshot_details(virtual_machine: virtualbox.lib.IMachine) -> list:
     """
     Loads snapshot details from a virtual machine.
 
     :param virtualbox.lib.IMachine virtual_machine: virtual machine no find snapshots for
-    :rtype: list or None
-    :return: If snapshot(s) exist - found snapshot list, None otherwise
+    :rtype: list
+    :return: If snapshot(s) exist - found snapshot list, empty list otherwise
     """
     # Snapshot ids[0], names[1], descriptions[2] are sorted from oldest (index 0) to newest
     snapshot_details = []
@@ -229,7 +229,7 @@ def load_snapshot_details(virtual_machine: virtualbox.lib.IMachine):
     except virtualbox.lib.VBoxError as ex:
         # Machine does not have any snapshots or no snapshots found
         logger.warning("No snapshots found. Reason: %s", ex.msg)
-        return None
+        return []
 
     snapshot_details.append([snapshot.id_p, snapshot.name, snapshot.description])
 
@@ -243,13 +243,13 @@ def load_snapshot_details(virtual_machine: virtualbox.lib.IMachine):
     return snapshot_details
 
 
-def list_snapshots(machine_name: str, snapshot_details: list):
+def list_snapshots(machine_name: str, snapshot_details: list) -> None:
     """
     Prints all available (if any) snapshot details.
 
     :return: None
     """
-    if snapshot_details is None:
+    if not snapshot_details:
         print(f"No snapshots found for '{machine_name}'")
     else:
         # Avoiding to use logger here to not clutter output which may be of some use for user

--- a/virtualbox_snapshotter.py
+++ b/virtualbox_snapshotter.py
@@ -227,9 +227,8 @@ def load_snapshot_details(virtual_machine: virtualbox.lib.IMachine):
         # Getting root snapshot and adding it to a list
         snapshot = virtual_machine.find_snapshot("")
     except virtualbox.lib.VBoxError as ex:
-        # Machine does not have any snapshots
-        logger.info("Cannot find and load any snapshots due to VBoxError: 0x%x (%s)",
-                    ex.value, ex.msg)
+        # Machine does not have any snapshots or no snapshots found
+        logger.warning("No snapshots found. Reason: %s", ex.msg)
         return None
 
     snapshot_details.append([snapshot.id_p, snapshot.name, snapshot.description])


### PR DESCRIPTION
Hey!

Sorry for a poor quality PR last time. I am looking into something, that may notify us about bugs before going into release.

In a meanwhile, I have done some work. I was inspired by your way of handling errors, so I reworked all of the errors to use your approach.

Release notes:
- BUGFIX: `-l` or `--list` was not triggering application exit if there were no snapshots found
- NEW FEATURE: Added application return codes. Updated README with a brief mention of expected return codes
- Removed exception trace whenever exception is raised. Now, only error number and error message will be displayed
- Minor improvements

I think it may be a worthy of a release `v1.2.1` as it fixes a behaviour, that users are not expecting. Honestly, it may even be `v1.3.0` as exit codes is a new feature and it could be handy for some people.